### PR TITLE
Updating roles to follow a `role-X` boolean pattern

### DIFF
--- a/bundle.yaml.j2
+++ b/bundle.yaml.j2
@@ -32,8 +32,6 @@ applications:
     channel: {{ channel|default('edge', true) }}
     {%- endif %}
     scale: 3
-    options:
-      role: "all"
     constraints: arch=amd64
     trust: true
     resources:
@@ -49,7 +47,8 @@ applications:
     {%- endif %}
     scale:  {{ 3 if mode == 'recommended-microservices' and role == 'ingester' else 1 }}
     options:
-      role: "{{ role }}"
+      role-all: false
+      role-{{ role }}: true
     constraints: arch=amd64
     trust: true
     resources:


### PR DESCRIPTION
## Issue
As part of https://github.com/canonical/tempo-worker-k8s-operator/pull/15, Tempo roles were changed to follow a `role-X` boolean pattern, instead of passing each role as a `string`.


## Solution
Update the bundle to follow the same pattern.